### PR TITLE
fix: add DNS fallback for NewPipe stream resolution

### DIFF
--- a/app/src/main/kotlin/app/vimusic/android/extractor/NewPipeDownloader.kt
+++ b/app/src/main/kotlin/app/vimusic/android/extractor/NewPipeDownloader.kt
@@ -1,11 +1,16 @@
 package app.vimusic.android.extractor
 
+import android.util.Log
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.downloader.Downloader
 import org.schabi.newpipe.extractor.downloader.Request
 import org.schabi.newpipe.extractor.downloader.Response
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.util.concurrent.TimeUnit
 
 class NewPipeDownloader(
     private val client: OkHttpClient
@@ -45,5 +50,56 @@ class NewPipeDownloader(
     companion object {
         const val USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0"
+
+        fun client(dnsTarget: NewPipeDnsTarget) = OkHttpClient.Builder()
+            .retryOnConnectionFailure(dnsTarget == NewPipeDnsTarget.System)
+            .connectTimeout(if (dnsTarget == NewPipeDnsTarget.System) 10 else 4, TimeUnit.SECONDS)
+            .readTimeout(if (dnsTarget == NewPipeDnsTarget.System) 10 else 8, TimeUnit.SECONDS)
+            .dns { hostname ->
+                when (dnsTarget) {
+                    NewPipeDnsTarget.System -> InetAddress.getAllByName(hostname).toList()
+                    is NewPipeDnsTarget.Resolved -> resolveAddresses(hostname, dnsTarget.index)
+                }
+            }
+            .build()
+
+        private fun resolveAddresses(hostname: String, index: Int): List<InetAddress> {
+            val addresses = InetAddress.getAllByName(hostname).toList()
+            val ordered = addresses
+                .filterIsInstance<Inet4Address>()
+                .zipLongest(addresses.filterIsInstance<Inet6Address>())
+                .flatMap { (ipv4, ipv6) -> listOfNotNull(ipv4, ipv6) }
+
+            val selected = ordered.getOrNull(index) ?: return addresses.also {
+                Log.d(TAG, "Using system DNS hostname=$hostname index=$index addresses=${addresses.size}")
+            }
+
+            return listOf(selected.also {
+                Log.d(TAG, "Resolved DNS hostname=$hostname index=$index address=${it.hostAddress}")
+            })
+        }
+
+        private fun <T> List<T>.zipLongest(other: List<T>): List<Pair<T?, T?>> {
+            val maxSize = maxOf(size, other.size)
+            return (0 until maxSize).map { index ->
+                getOrNull(index) to other.getOrNull(index)
+            }
+        }
+
+        private const val TAG = "NewPipeDownloader"
+    }
+}
+
+sealed interface NewPipeDnsTarget {
+    val label: String
+
+    data object System : NewPipeDnsTarget {
+        override val label = "system"
+    }
+
+    data class Resolved(
+        val index: Int
+    ) : NewPipeDnsTarget {
+        override val label = "resolved[$index]"
     }
 }

--- a/app/src/main/kotlin/app/vimusic/android/extractor/NewPipeExtractorClient.kt
+++ b/app/src/main/kotlin/app/vimusic/android/extractor/NewPipeExtractorClient.kt
@@ -1,6 +1,6 @@
 package app.vimusic.android.extractor
 
-import okhttp3.OkHttpClient
+import android.util.Log
 import org.schabi.newpipe.extractor.NewPipe
 import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.exceptions.ExtractionException
@@ -14,18 +14,12 @@ import java.io.IOException
 
 object NewPipeExtractorClient {
     private var initialized = false
+    private val lock = Any()
+    private var lastSuccessfulDnsIndex: Int? = null
 
     fun ensureInitialized() {
         if (initialized) return
-        NewPipe.init(
-            NewPipeDownloader(
-                OkHttpClient.Builder()
-                    .retryOnConnectionFailure(true)
-                    .build()
-            ),
-            Localization.DEFAULT,
-            ContentCountry.DEFAULT
-        )
+        configureDownloader(NewPipeDnsTarget.System)
         initialized = true
     }
 
@@ -33,13 +27,59 @@ object NewPipeExtractorClient {
     fun resolveAudioStream(videoId: String): NewPipeAudioResult {
         ensureInitialized()
 
+        synchronized(lock) {
+            var firstError: Throwable? = null
+            var lastError: Throwable? = null
+
+            dnsFallbackTargets().forEach { dnsTarget ->
+                runCatching {
+                    Log.d(TAG, "Resolving audio stream videoId=$videoId dnsTarget=${dnsTarget.label}")
+                    val result = resolveAudioStream(videoId, dnsTarget)
+                    if (dnsTarget is NewPipeDnsTarget.Resolved) {
+                        lastSuccessfulDnsIndex = dnsTarget.index
+                    }
+                    return result
+                }.onFailure { error ->
+                    Log.w(TAG, "Audio stream resolve failed videoId=$videoId dnsTarget=${dnsTarget.label}", error)
+                    if (firstError == null) firstError = error
+                    lastError = error
+                }
+            }
+
+            lastError?.let { error ->
+                firstError?.takeIf { it !== error }?.let(error::addSuppressed)
+                throw error
+            }
+
+            throw ExtractionException("No DNS fallback targets configured")
+        }
+    }
+
+    @Throws(IOException::class, ExtractionException::class)
+    private fun resolveAudioStream(videoId: String, dnsTarget: NewPipeDnsTarget): NewPipeAudioResult {
+        configureDownloader(dnsTarget)
+
         val url = "https://www.youtube.com/watch?v=$videoId"
         val service = ServiceList.YouTube as YoutubeService
         val streamInfo = StreamInfo.getInfo(service, url)
         val audioStream = selectBestAudioStream(streamInfo.audioStreams)
             ?: throw ExtractionException("No playable audio stream found")
 
+        Log.i(
+            TAG,
+            "Audio stream resolved videoId=$videoId dnsTarget=${dnsTarget.label} " +
+                "itag=${audioStream.itag} bitrate=${audioStream.averageBitrate}"
+        )
+
         return NewPipeAudioResult(streamInfo, audioStream)
+    }
+
+    private fun configureDownloader(dnsTarget: NewPipeDnsTarget) {
+        NewPipe.init(
+            NewPipeDownloader(NewPipeDownloader.client(dnsTarget)),
+            Localization.DEFAULT,
+            ContentCountry.DEFAULT
+        )
     }
 
     private fun selectBestAudioStream(streams: List<AudioStream>?): AudioStream? {
@@ -56,6 +96,22 @@ object NewPipeExtractorClient {
 
         return candidates.firstOrNull()
     }
+
+    private fun dnsFallbackTargets(): List<NewPipeDnsTarget> {
+        val startIndex = lastSuccessfulDnsIndex
+            ?.plus(1)
+            ?.mod(DNS_RESOLVED_ADDRESS_ATTEMPTS)
+            ?: 0
+
+        val resolvedTargets = (0 until DNS_RESOLVED_ADDRESS_ATTEMPTS).map { offset ->
+            NewPipeDnsTarget.Resolved((startIndex + offset) % DNS_RESOLVED_ADDRESS_ATTEMPTS)
+        }
+
+        return resolvedTargets + NewPipeDnsTarget.System
+    }
+
+    private const val TAG = "NewPipeExtractorClient"
+    private const val DNS_RESOLVED_ADDRESS_ATTEMPTS = 20
 }
 
 data class NewPipeAudioResult(


### PR DESCRIPTION
probably caused by YouTube API restrictions.
it tries both A and AAAA records, so basically IPv4 and IPv6.

playback was still running after I woke up, so it’s probably okay now.