### PR TITLE
fix: restore quick picks recommendations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -209,7 +209,7 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.okhttp.brotli)
     // KatHttp3 code and native libraries exist only in the HTTP/3 source set.
-    add("http3Implementation", "com.github.haturatu:kathttp3:v0.1.30")
+    add("http3Implementation", "com.github.haturatu:kathttp3:v0.1.31")
     implementation(libs.newpipe.nanojson)
     implementation(libs.re2j)
     implementation("com.github.TeamNewPipe:NewPipeExtractor:v0.26.4")

--- a/app/src/main/kotlin/app/vimusic/android/ui/modifiers/SongSwipeActions.kt
+++ b/app/src/main/kotlin/app/vimusic/android/ui/modifiers/SongSwipeActions.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.MediaItem
+import app.vimusic.android.R
 import app.vimusic.android.LocalAppContainer
 import app.vimusic.android.LocalPlayerServiceBinder
 import app.vimusic.android.models.Song
@@ -36,6 +37,12 @@ fun Modifier.songSwipeActions(
         requireUnconsumed = requireUnconsumed,
         enableSwipeLeft = canSwipeLeft,
         enableSwipeRight = AppearancePreferences.swipeRightToPlayNext,
+        leftActionIcon = if (canSwipeLeft) R.drawable.trash else null,
+        rightActionIcon = if (AppearancePreferences.swipeRightToPlayNext) {
+            R.drawable.play_skip_forward
+        } else {
+            null
+        },
         onSwipeLeft = { animationJob ->
             if (canSwipeLeft) {
                 val song = requireNotNull(songToHide)

--- a/app/src/main/kotlin/app/vimusic/android/ui/modifiers/Swiping.kt
+++ b/app/src/main/kotlin/app/vimusic/android/ui/modifiers/Swiping.kt
@@ -331,9 +331,9 @@ fun Modifier.swipeToAction(
                 val horizontalPadding = 16.dp.toPx()
                 val iconAlpha = (kotlin.math.abs(currentOffsetPx) / currentWidth).coerceIn(0f, 1f)
                 val iconLeft = if (currentOffsetPx < 0) {
-                    horizontalPadding
-                } else {
                     size.width - iconSize - horizontalPadding
+                } else {
+                    horizontalPadding
                 }
 
                 translate(iconLeft, (size.height - iconSize) / 2f) {

--- a/app/src/main/kotlin/app/vimusic/android/ui/modifiers/Swiping.kt
+++ b/app/src/main/kotlin/app/vimusic/android/ui/modifiers/Swiping.kt
@@ -1,5 +1,6 @@
 package app.vimusic.android.ui.modifiers
 
+import androidx.annotation.DrawableRes
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.AnimationVector1D
@@ -25,15 +26,22 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import app.vimusic.core.ui.LocalAppearance
 import app.vimusic.core.ui.utils.px
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
@@ -273,12 +281,17 @@ fun Modifier.swipeToAction(
     requireUnconsumed: Boolean = false,
     enableSwipeLeft: Boolean = true,
     enableSwipeRight: Boolean = true,
+    @DrawableRes leftActionIcon: Int? = null,
+    @DrawableRes rightActionIcon: Int? = null,
     onSwipeLeft: suspend (animationJob: Job) -> Unit = { },
     onSwipeRight: suspend (animationJob: Job) -> Unit = { }
 ) = this.composed {
     val swipeState = state ?: rememberSwipeState(key)
 
     val density = LocalDensity.current
+    val (colorPalette) = LocalAppearance.current
+    val leftPainter = leftActionIcon?.let { painterResource(it) }
+    val rightPainter = rightActionIcon?.let { painterResource(it) }
 
     var currentWidth by remember { mutableIntStateOf(0) }
     val currentWidthDp by remember { derivedStateOf { currentWidth.px.dp(density) } }
@@ -306,7 +319,37 @@ fun Modifier.swipeToAction(
 
     this
         .onSizeChanged { currentWidth = it.width }
-        .alpha(alpha)
+        .drawWithContent {
+            val actionPainter = when {
+                currentOffsetPx < 0 -> leftPainter
+                currentOffsetPx > 0 -> rightPainter
+                else -> null
+            }
+
+            if (actionPainter != null && currentWidth > 0) {
+                val iconSize = 24.dp.toPx()
+                val horizontalPadding = 16.dp.toPx()
+                val iconAlpha = (kotlin.math.abs(currentOffsetPx) / currentWidth).coerceIn(0f, 1f)
+                val iconLeft = if (currentOffsetPx < 0) {
+                    horizontalPadding
+                } else {
+                    size.width - iconSize - horizontalPadding
+                }
+
+                translate(iconLeft, (size.height - iconSize) / 2f) {
+                    with(actionPainter) {
+                        draw(
+                            size = Size(iconSize, iconSize),
+                            alpha = iconAlpha,
+                            colorFilter = ColorFilter.tint(colorPalette.text)
+                        )
+                    }
+                }
+            }
+
+            drawContent()
+        }
+        .graphicsLayer(alpha = alpha)
         .onSwipe(
             state = swipeState,
             key = key,

--- a/providers/youtube-music/src/main/kotlin/app/vimusic/providers/youtubemusic/innertube/requests/RelatedPage.kt
+++ b/providers/youtube-music/src/main/kotlin/app/vimusic/providers/youtubemusic/innertube/requests/RelatedPage.kt
@@ -24,7 +24,7 @@ suspend fun YoutubeMusicInnertube.relatedPage(body: NextBody) = runCatchingCance
         ?.tabbedRenderer
         ?.watchNextTabbedResultsRenderer
         ?.tabs
-        ?.getOrNull(2)
+        ?.firstOrNull { it.tabRenderer?.title == "Related" }
         ?.tabRenderer
         ?.endpoint
         ?.browseEndpoint


### PR DESCRIPTION
## Summary

- Display the configured action icon while swiping a song item.
- Select the `Related` watch-next tab by title instead of a fixed tab index.
- Upgrade the HTTP/3 transport dependency to kathttp3 v0.1.31.

## Root cause

YouTube Music added a `Comments` tab before `Related`. The quick-picks request expected `Related` at index 2, so it received no browse ID and treated the response as empty.

Closes #146

## Validation

- `NEWPIPE_EXTRACTOR_DIR=build/newpipeextractor ./gradlew :app:compileHttp3DebugKotlin --no-daemon`
- `NEWPIPE_EXTRACTOR_DIR=build/newpipeextractor ./gradlew detekt --no-daemon`
- Installed the HTTP/3 debug APK and confirmed via ADB that Quick Picks displays related content and completes both `next` and `browse` requests with HTTP 200.