### PR TITLE
fix: sanitize FTS search query to prevent SQLite MATCH crash

### DIFF
--- a/app/src/main/kotlin/app/vimusic/android/repositories/SongsRepository.kt
+++ b/app/src/main/kotlin/app/vimusic/android/repositories/SongsRepository.kt
@@ -90,7 +90,13 @@ object DatabaseSongsRepository : SongsRepository {
     }
 }
 
-fun String.toFtsPrefixQuery(): String =
-    trim().split(Regex("\\s+")).filter(String::isNotBlank).joinToString(" AND ") { token ->
-        "\"${token.replace("\"", "\"\"")}\"*"
-    }
+fun String.toFtsPrefixQuery(): String {
+    val tokens = trim()
+        .split(Regex("\\s+"))
+        .map { token -> token.filter { it != '"' } }
+        .filter(String::isNotBlank)
+
+    if (tokens.isEmpty()) return ""
+
+    return tokens.joinToString(" AND ") { "\"$it\"*" }
+}


### PR DESCRIPTION
## Problem

Chaos/fuzz testing found that any search query containing a double quote (e.g. typing the title `"In Da Club"`) crashes the app with an uncaught `android.database.sqlite.SQLiteException: malformed MATCH expression (unterminated string)`.

`SongsRepository.toFtsPrefixQuery` doubled `"` inside a token. FTS4 does not treat doubled quotes as an escape; the produced `MATCH` string stays unterminated and the statement fails. Reproduced with sqlite3 + bound parameters:

```
CREATE VIRTUAL TABLE t USING fts4(title, artistsText);
SELECT rowid FROM t WHERE t MATCH '"""*';  -- OperationalError: malformed MATCH expression
```

## Fix

Strip `"` characters from each token before wrapping it in a quoted prefix phrase, and drop tokens that become blank. A query made exclusively of quotes degrades to an empty (zero-row) match instead of a crash.

## Verification

Fuzzed the resulting queries against real FTS4 with bound parameters (mirroring Room's parameter binding); all prior crash inputs now return empty result sets or valid matches.