### PR TITLE
fix: bound explicit-skip scan in forceSeekToPrevious to avoid infinite loop

### DIFF
--- a/app/src/main/kotlin/app/vimusic/android/utils/Player.kt
+++ b/app/src/main/kotlin/app/vimusic/android/utils/Player.kt
@@ -70,13 +70,16 @@ fun Player.forceSeekToPrevious(
     hideExplicit -> if (mediaItemCount <= 1) forceSeekToPrevious(hideExplicit = false)
     else {
         var i = currentMediaItemIndex - 1
-        while (
-            i !in (0 until mediaItemCount) ||
-            getMediaItemAt(i).mediaMetadata.extras?.songBundle?.explicit == true
-        ) {
-            if (i <= 0) i = mediaItemCount - 1 else i--
+        var scanned = 0
+        while (scanned < mediaItemCount) {
+            if (i < 0) i = mediaItemCount - 1
+            if (getMediaItemAt(i).mediaMetadata.extras?.songBundle?.explicit != true) {
+                return seekTo(i, C.TIME_UNSET)
+            }
+            i--
+            scanned++
         }
-        seekTo(i, C.TIME_UNSET)
+        return forceSeekToPrevious(hideExplicit = false)
     }
     // fall back to default behavior if there is only a single song
 


### PR DESCRIPTION
## Problem

Chaos/fuzz testing found an infinite loop / ANR in `Player.forceSeekToPrevious` (used by the notification, Android Auto and on-screen Previous buttons when "hide explicit songs" is enabled).

When no non-explicit song exists among the preceding items (e.g. an all-explicit queue of 2+ songs, or a single explicit track reached from an explicit tail), the backward scan wraps forever:

```
while (i !in (0 until mediaItemCount) || isExplicitAt(i)) {
    if (i <= 0) i = mediaItemCount - 1 else i--
}
```

With `mediaItemCount == 2` and both items explicit, `i` oscillates between `0` and `1` in the main thread, freezing the UI until ANR.

## Fix

Bound the scan to `mediaItemCount` probes (i.e. at most one full wrap around the timeline). If no eligible predecessor is found, fall back to the default previous-track behavior.

## Verification

Traced the new loop for all-explicit queues of size 2 and N; it always terminates and hands off to the default behavior instead of hanging.