### PR TITLE
fix: create FTS content-sync triggers in 30 to 31 migration

### DIFF
--- a/app/src/main/kotlin/app/vimusic/android/Database.kt
+++ b/app/src/main/kotlin/app/vimusic/android/Database.kt
@@ -1288,6 +1288,24 @@ abstract class DatabaseInitializer protected constructor() : RoomDatabase() {
                         "`title` TEXT NOT NULL, `artistsText` TEXT, content=`Song`)"
             )
             db.execSQL("INSERT INTO `SongFts`(`SongFts`) VALUES('rebuild')")
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_SongFts_BEFORE_UPDATE " +
+                        "BEFORE UPDATE ON `Song` BEGIN DELETE FROM `SongFts` WHERE `docid`=OLD.`rowid`; END"
+            )
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_SongFts_BEFORE_DELETE " +
+                        "BEFORE DELETE ON `Song` BEGIN DELETE FROM `SongFts` WHERE `docid`=OLD.`rowid`; END"
+            )
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_SongFts_AFTER_UPDATE " +
+                        "AFTER UPDATE ON `Song` BEGIN INSERT INTO `SongFts`(`docid`, `title`, `artistsText`)" +
+                        " VALUES (NEW.`rowid`, NEW.`title`, NEW.`artistsText`); END"
+            )
+            db.execSQL(
+                "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_SongFts_AFTER_INSERT " +
+                        "AFTER INSERT ON `Song` BEGIN INSERT INTO `SongFts`(`docid`, `title`, `artistsText`)" +
+                        " VALUES (NEW.`rowid`, NEW.`title`, NEW.`artistsText`); END"
+            )
         }
     }
 }


### PR DESCRIPTION
## Problem

Chaos/fuzz testing of the Room migrations found that the version 30 -> 31 migration (`From30To31Migration`) creates the `SongFts` FTS4 table and rebuilds it once, but never creates the four content-sync triggers that Room emits in `createAllTables` (`room_fts_content_sync_SongFts_AFTER_INSERT`, `AFTER_UPDATE`, `BEFORE_UPDATE`, `BEFORE_DELETE` — present in `app/schemas/.../31.json`).

On any install that upgrades from DB version <= 30, every subsequent `Song` insert / update / delete silently never reaches `SongFts`, so the library search index becomes permanently stale: new and renamed songs never appear (or stay searchable after deletion) even though the app is on the new schema.

## Fix

Emit the same four `CREATE TRIGGER IF NOT EXISTS ...` statements (copied verbatim from the 31.json content-sync triggers) inside the migration, after creating the virtual table.

## Verification

`contentSyncTriggers` in `31.json` matches the added DDL exactly (names, `docid` handling, `OLD.`/`NEW.` quoting).