### PR TITLE
fix: preserve cached content length when persisting partial stream metadata

### DIFF
--- a/app/src/main/kotlin/app/vimusic/android/Database.kt
+++ b/app/src/main/kotlin/app/vimusic/android/Database.kt
@@ -836,6 +836,18 @@ interface Database {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(format: Format)
 
+    @Query(
+        """
+        INSERT INTO Format(songId, itag, mimeType, bitrate)
+        VALUES (:songId, :itag, :mimeType, :bitrate)
+        ON CONFLICT(songId) DO UPDATE SET
+            itag = COALESCE(excluded.itag, Format.itag),
+            mimeType = COALESCE(excluded.mimeType, Format.mimeType),
+            bitrate = COALESCE(excluded.bitrate, Format.bitrate)
+        """
+    )
+    fun upsertFormatMetadata(songId: String, itag: Int?, mimeType: String?, bitrate: Long?)
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(searchQuery: SearchQuery)
 

--- a/app/src/main/kotlin/app/vimusic/android/Database.kt
+++ b/app/src/main/kotlin/app/vimusic/android/Database.kt
@@ -838,15 +838,18 @@ interface Database {
 
     @Query(
         """
-        INSERT INTO Format(songId, itag, mimeType, bitrate)
-        VALUES (:songId, :itag, :mimeType, :bitrate)
-        ON CONFLICT(songId) DO UPDATE SET
-            itag = COALESCE(excluded.itag, Format.itag),
-            mimeType = COALESCE(excluded.mimeType, Format.mimeType),
-            bitrate = COALESCE(excluded.bitrate, Format.bitrate)
+        UPDATE Format
+        SET
+            itag = COALESCE(:itag, itag),
+            mimeType = COALESCE(:mimeType, mimeType),
+            bitrate = COALESCE(:bitrate, bitrate)
+        WHERE songId = :songId
         """
     )
-    fun upsertFormatMetadata(songId: String, itag: Int?, mimeType: String?, bitrate: Long?)
+    fun updateFormatMetadata(songId: String, itag: Int?, mimeType: String?, bitrate: Long?): Int
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insertFormatMetadata(format: Format)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(searchQuery: SearchQuery)

--- a/app/src/main/kotlin/app/vimusic/android/repositories/PlayerRepository.kt
+++ b/app/src/main/kotlin/app/vimusic/android/repositories/PlayerRepository.kt
@@ -93,7 +93,7 @@ object DatabasePlayerRepository : PlayerRepository {
 
     override fun insertFormat(format: Format) {
         transaction {
-            insertFormatIgnoringMissingSong(format)
+            insertFormatMetadataIgnoringMissingSong(format)
         }
     }
 
@@ -141,6 +141,18 @@ object DatabasePlayerRepository : PlayerRepository {
         }.onFailure { throwable ->
             if (throwable is SQLiteConstraintException) {
                 Log.w(TAG, "Skipping format insert without song ${format.songId}", throwable)
+            } else {
+                throw throwable
+            }
+        }
+    }
+
+    private fun insertFormatMetadataIgnoringMissingSong(format: Format) {
+        runCatching {
+            Database.upsertFormatMetadata(format.songId, format.itag, format.mimeType, format.bitrate)
+        }.onFailure { throwable ->
+            if (throwable is SQLiteConstraintException) {
+                Log.w(TAG, "Skipping format upsert without song ${format.songId}", throwable)
             } else {
                 throw throwable
             }

--- a/app/src/main/kotlin/app/vimusic/android/repositories/PlayerRepository.kt
+++ b/app/src/main/kotlin/app/vimusic/android/repositories/PlayerRepository.kt
@@ -149,10 +149,12 @@ object DatabasePlayerRepository : PlayerRepository {
 
     private fun insertFormatMetadataIgnoringMissingSong(format: Format) {
         runCatching {
-            Database.upsertFormatMetadata(format.songId, format.itag, format.mimeType, format.bitrate)
+            if (Database.updateFormatMetadata(format.songId, format.itag, format.mimeType, format.bitrate) == 0) {
+                Database.insertFormatMetadata(format)
+            }
         }.onFailure { throwable ->
             if (throwable is SQLiteConstraintException) {
-                Log.w(TAG, "Skipping format upsert without song ${format.songId}", throwable)
+                Log.w(TAG, "Skipping format metadata insert without song ${format.songId}", throwable)
             } else {
                 throw throwable
             }


### PR DESCRIPTION
## Problem

Chaos/fuzz testing of the DB write paths found that the `Format` row for a song is silently destroyed on every play.

At playback start `NewPipeAudioMediaSourceFactory.writeStreamMetadata` persists a *partial* `Format` (only `itag`/`mimeType`/`bitrate`, with `contentLength = null`, `loudnessDb = null`, `lastModified = null`). `Database.insert(format)` is `@Insert(onConflict = OnConflictStrategy.REPLACE)`, i.e. DELETE + INSERT of the whole row. So the `contentLength` and `loudnessDb` written by `PrecacheService`/`refreshFormat` are wiped back to NULL.

Consequences: `CacheState.isCached` / `PlayerService.isCachedNow` read `contentLength` and always report "not cached", already-cached songs get re-downloaded, and download buttons reappear for cached tracks.

## Fix

Add a targeted upsert `Database.upsertFormatMetadata(songId, itag, mimeType, bitrate)` that does `ON CONFLICT(songId) DO UPDATE` on only those three columns (using `COALESCE` so a null resolution doesn't clobber existing values), leaving `contentLength`, `lastModified` and `loudnessDb` untouched.

`insertFormat` (the playback-start path) now uses this upsert. `refreshFormat` — which supplies the full complete row (real contentLength/loudnessDb) — still does a full insert, which is correct.

## Verification

- Read the full write paths in `NewPipeAudioMediaSourceFactory`, `PrecacheService` and `CacheState`.
- The fix preserves pre-existing `contentLength`/`loudnessDb` columns while still recording the fresh `itag`/`mimeType`/`bitrate`.