### PR TITLE
fix: chunk playlist song inserts to stay under SQLite bind variable limit

### DIFF
--- a/app/src/main/kotlin/app/vimusic/android/repositories/LocalPlaylistRepository.kt
+++ b/app/src/main/kotlin/app/vimusic/android/repositories/LocalPlaylistRepository.kt
@@ -28,6 +28,8 @@ interface LocalPlaylistRepository {
 }
 
 object DatabaseLocalPlaylistRepository : LocalPlaylistRepository {
+    private const val SONGS_BATCH_SIZE = 300
+
     override fun observePlaylist(playlistId: Long): Flow<Playlist?> = Database.playlist(playlistId)
 
     override fun observePlaylistSongs(playlistId: Long): Flow<List<Song>> = Database.playlistSongs(playlistId)
@@ -69,7 +71,8 @@ object DatabaseLocalPlaylistRepository : LocalPlaylistRepository {
                             position = position
                         )
                     }
-                    ?.let(Database::insertSongPlaylistMaps)
+                    ?.chunked(SONGS_BATCH_SIZE)
+                    ?.forEach(Database::insertSongPlaylistMaps)
             }
         }
     }.onFailure {

--- a/app/src/main/kotlin/app/vimusic/android/repositories/PlaylistRepository.kt
+++ b/app/src/main/kotlin/app/vimusic/android/repositories/PlaylistRepository.kt
@@ -28,6 +28,8 @@ interface PlaylistRepository {
 }
 
 object DatabasePlaylistRepository : PlaylistRepository {
+    private const val SONGS_BATCH_SIZE = 300
+
     override suspend fun fetchPlaylistPage(
         browseId: String,
         params: String?,
@@ -65,7 +67,8 @@ object DatabasePlaylistRepository : PlaylistRepository {
                             position = index
                         )
                     }
-                    ?.let(Database::insertSongPlaylistMaps)
+                    ?.chunked(SONGS_BATCH_SIZE)
+                    ?.forEach(Database::insertSongPlaylistMaps)
             }
         }
     }


### PR DESCRIPTION
## Problem

Chaos/fuzz testing of the DB write paths found that importing or syncing a playlist with 334+ songs crashes the app (import) or silently fails (sync).

`Database.insertSongPlaylistMaps(List<SongPlaylistMap>)` is a Room `@Insert` on a list, which emits ONE multi-row statement with 3 bind variables per row. SQLite caps bind variables at 999 (Android <= 11) / 32766 (newer) per statement, so any playlist larger than ~333 songs throws `SQLiteException: too many SQL variables`.

- `PlaylistRepository.importPlaylist` runs it inside `query { transaction { ... } }` with no exception handler → process crash.
- `LocalPlaylistRepository.sync` swallows the failure via `runSuspendCatching { ... }` → playlist stays stale silently.

## Fix

Chunk the map list into batches of 300 (900 bind variables < the smallest 999 cap) and insert each batch on its own statement. Both `importPlaylist` and `sync` apply the same chunking inside their existing transaction.

## Verification

Batched inserts keep every row in the same transaction; a 1000-song import now issues 4 statements of 300 rows instead of one 3000-variable statement that exceeds the limit.