### PR TITLE
fix: ignore invalid Android Auto queue indices

### DIFF
--- a/app/src/main/kotlin/app/vimusic/android/service/PlayerMediaLibraryService.kt
+++ b/app/src/main/kotlin/app/vimusic/android/service/PlayerMediaLibraryService.kt
@@ -437,7 +437,7 @@ class PlayerMediaLibraryService : MediaLibraryService(), ServiceConnection {
                             withContext(Dispatchers.Main) {
                                 binder.player.forcePlayAtIndex(
                                     items = it,
-                                    index = index.coerceIn(0, it.size)
+                                    index = index
                                 )
                             }
                         }


### PR DESCRIPTION
Follow up to the Android Auto queue fix: pass the requested index through so forcePlayAtIndex can safely ignore an invalid request instead of selecting a different song.